### PR TITLE
Version bump to v1.6.3

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return [
     'label' => 'FooBar power extension yes',
     'description' => 'Dummy test extension',
     'license' => 'GPL-2.0',
-    'version' => '1.6.2',
+    'version' => '1.6.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=21.0.1'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -34,6 +34,6 @@ class Updater extends \common_ext_ExtensionUpdater
      */
     public function update($initialVersion)
     {
-        $this->skip('0.1.0', '1.6.2');
+        $this->skip('0.1.0', '1.6.3');
     }
 }


### PR DESCRIPTION
> Assignee deliberately left blank to check release note extraction.